### PR TITLE
Bump to version 1.0.2. 

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Blues Notecard Environment Variable Manager
-version=1.0.0
+version=1.0.2
 author=Blues
 maintainer=Blues <info@blues.io>
 sentence=A utility class to support usage and management of Notecard-based environment variables.


### PR DESCRIPTION
This is identical to 1.0.1 aside from the fact that library.properties says version 1.0.2 now. We didn't bump the library.properties version on the change from 1.0.0 to 1.0.1, so 1.0.1 was never picked up by the Arduino library manager. This new release is to fix this problem.